### PR TITLE
Implement service name extractors

### DIFF
--- a/service_report.py
+++ b/service_report.py
@@ -18,6 +18,10 @@ from src.report_writer import write_service_html
 from src.stop_times import get_stops_for_trips
 from src.routes import load_routes
 from src.report_data import get_service_report_data
+# Service extractor imports
+from src.service_extractor.default import DefaultServiceExtractor
+from src.service_extractor.lcg_muni import LcgMunicipalServiceExtractor
+from src.service_extractor.vgo_muni import VgoMunicipalServiceExtractor
 
 logger = get_logger("service_report")
 
@@ -92,6 +96,7 @@ def parse_args():
     parser.add_argument('--output-dir', type=str, default="./output/", help='Directory to write reports to (default: ./output/)')
     parser.add_argument('--feed-dir', type=str, help="Path to the feed directory")
     parser.add_argument('--feed-url', type=str, help="URL to download the GTFS feed from (if not using local feed directory)")
+    parser.add_argument('--service-extractor', type=str, default="default", help="Service extractor to use (default|lcg_muni|vgo_muni)")
     args = parser.parse_args()
 
     if not args.all_dates and not args.start_date:
@@ -118,6 +123,16 @@ def main():
     else:
         logger.info(f"Downloading GTFS feed from {feed_url}...")
         feed_dir = download_feed_from_url(feed_url)
+
+
+    # Select service extractor based on argument
+    extractor_arg = getattr(args, 'service_extractor', 'default')
+    if extractor_arg == 'lcg_muni':
+        service_extractor = LcgMunicipalServiceExtractor
+    elif extractor_arg == 'vgo_muni':
+        service_extractor = VgoMunicipalServiceExtractor
+    else:
+        service_extractor = DefaultServiceExtractor
 
     if args.all_dates:
         all_dates = get_all_feed_dates(feed_dir)
@@ -166,6 +181,12 @@ def main():
         date_dir = os.path.join(output_dir, current_date)
         os.makedirs(date_dir, exist_ok=True)
         for service_id, trip_list in trips.items():
+            # Extract human-readable service name using the selected extractor
+            try:
+                service_name = service_extractor.extract_service_name_from_identifier(service_id)
+            except Exception as e:
+                logger.warning(f"Failed to extract service name for {service_id}: {e}")
+                service_name = service_id
             try:
                 # Restore the assignment of route_short_name and route_color to each trip
                 for trip in trip_list:
@@ -283,6 +304,7 @@ def main():
                 # Append enriched service info
                 generated_services.append({
                     "service_id": service_id,
+                    "service_name": service_name,
                     "filename": filename,
                     "first_departure": first_departure,
                     "last_arrival": last_arrival,

--- a/src/service_extractor/default.py
+++ b/src/service_extractor/default.py
@@ -1,0 +1,25 @@
+from abc import abstractmethod
+
+
+class AbstractServiceExtractor:
+    """
+    Abstract base class for service extractors.
+    """
+    @abstractmethod
+    def extract_service_name_from_identifier(self, service_identifier: str) -> str:
+        pass
+
+class DefaultServiceExtractor(AbstractServiceExtractor):
+    @staticmethod
+    def extract_service_name_from_identifier(service_identifier: str) -> str:
+        """
+        Extracts the actual service code from the service identifier. The default
+        implementation simply returns the service identifier as is.
+        
+        Args:
+            service_identifier (str): The service identifier from which to extract the code.
+
+        Returns:
+            str: The code of the service.
+        """
+        return service_identifier

--- a/src/service_extractor/lcg_muni.py
+++ b/src/service_extractor/lcg_muni.py
@@ -1,0 +1,24 @@
+from src.service_extractor.default import AbstractServiceExtractor
+
+
+class LcgMunicipalServiceExtractor(AbstractServiceExtractor):
+    @staticmethod
+    def extract_service_name_from_identifier(service_identifier: str) -> str:
+        """
+        Extracts the actual service code from the service identifier for A Coruña GTFS.
+        The service identifier is composed as follows:
+        - [service_code][calendar_type][departure_time]
+        - service_code: variable length (at least 2 digits, can be more)
+        - calendar_type: always 2 digits
+        - departure_time: always 4 digits
+
+        Args:
+            service_identifier (str): The service identifier from which to extract the code.
+
+        Returns:
+            str: The code of the service (service_code part).
+        """
+        if not service_identifier or len(service_identifier) < 7:
+            raise ValueError("Invalid service identifier: must be at least 7 characters long")
+        # Remove last 6 characters (2 for calendar type, 4 for departure time)
+        return service_identifier[:-6]

--- a/src/service_extractor/vgo_muni.py
+++ b/src/service_extractor/vgo_muni.py
@@ -1,0 +1,17 @@
+from src.service_extractor.default import AbstractServiceExtractor
+
+
+class VgoMunicipalServiceExtractor(AbstractServiceExtractor):
+    @staticmethod
+    def extract_service_name_from_identifier(service_identifier: str) -> str:
+        """
+        Extracts the actual service code from the service identifier. The default
+        implementation simply returns the service identifier as is.
+        
+        Args:
+            service_identifier (str): The service identifier from which to extract the code.
+
+        Returns:
+            str: The code of the service.
+        """
+        return service_identifier

--- a/src/service_extractor/vgo_muni.py
+++ b/src/service_extractor/vgo_muni.py
@@ -1,3 +1,4 @@
+import re
 from src.service_extractor.default import AbstractServiceExtractor
 
 
@@ -5,8 +6,13 @@ class VgoMunicipalServiceExtractor(AbstractServiceExtractor):
     @staticmethod
     def extract_service_name_from_identifier(service_identifier: str) -> str:
         """
-        Extracts the actual service code from the service identifier. The default
-        implementation simply returns the service identifier as is.
+        Extracts the actual service code from the service identifier. In Vigo, the service
+        identifier contains a variable-length indicator with letters and stuff, an underscore and 
+        6 digits indicating the "main" line and the shift code.
+
+        For example:
+            "C1 01LPV00_001001" -> Line 001 (C1) shift 001
+            "C1 02LP100_001002" -> Line 001 (C1) shift 002
         
         Args:
             service_identifier (str): The service identifier from which to extract the code.
@@ -14,4 +20,18 @@ class VgoMunicipalServiceExtractor(AbstractServiceExtractor):
         Returns:
             str: The code of the service.
         """
-        return service_identifier
+        matches = re.match(r"^[A-Z0-9]+_([0-9]{6})$", service_identifier)
+        if not matches:
+            print(f"Invalid service identifier format: {service_identifier} - Returning as is")
+            return service_identifier
+        
+        # Take the second part only (first capture group)
+        service_code = matches.group(1)
+        if len(service_code) < 2:
+            print(f"Service code too short: {service_code} - Returning as is")
+            return service_identifier
+
+        line_number = int(service_code[:3]) # First three digits are the line number, let's parse it to integer to remove leading zeros
+        shift_code = int(service_code[3:])
+        return f"L{line_number} S{shift_code}º"
+        

--- a/tests/service_extractor/test_lcg_muni.py
+++ b/tests/service_extractor/test_lcg_muni.py
@@ -1,0 +1,19 @@
+import pytest
+from src.service_extractor.lcg_muni import LcgMunicipalServiceExtractor
+
+@pytest.mark.parametrize(
+    "service_identifier,expected",
+    [
+        ("100010731", "100"),
+        ("1501081246", "1501"),
+        ("2900070804", "2900"),
+        ("2201101700", "2201"),
+        ("2001031940", "2001"),
+    ]
+)
+def test_extract_service_name_from_identifier(service_identifier, expected):
+    assert LcgMunicipalServiceExtractor.extract_service_name_from_identifier(service_identifier) == expected
+
+def test_invalid_identifier_too_short():
+    with pytest.raises(ValueError):
+        LcgMunicipalServiceExtractor.extract_service_name_from_identifier("12345")


### PR DESCRIPTION
Implement extractors for the service names, pickable at runtime, so the service names indicated in the application matches the actual naming scheme used by each feed provider in reality.